### PR TITLE
feat: using triggers to trigger image builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Pino Baking
+# Caravan Baking
 
 #### Test list
 

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -4,6 +4,11 @@ terraform {
 
 resource "null_resource" "run_packer_google" {
   count = (var.build_on_google && ! var.skip_packer_build) ? 1 : 0
+  triggers = {
+    "changes-in-playbook" : filemd5("${path.module}/../ansible/centos-gcp.yml")
+    "changes-in-groupvars-all" : filemd5("${path.module}/../ansible/group_vars/all")
+    "changes-in-groupvars-gcp" : filemd5("${path.module}/../ansible/group_vars/centos_gcp")
+  }
   provisioner "local-exec" {
     working_dir = "${path.module}/../packer"
     command     = "packer build -force packer-centos-gcp.json"
@@ -23,6 +28,11 @@ resource "null_resource" "run_packer_google" {
 
 resource "null_resource" "run_packer_aws" {
   count = (var.build_on_aws && ! var.skip_packer_build) ? 1 : 0
+  triggers = {
+    "changes-in-playbook" : filemd5("${path.module}/../ansible/centos-aws.yml")
+    "changes-in-groupvars-all" : filemd5("${path.module}/../ansible/group_vars/all")
+    "changes-in-groupvars-aws" : filemd5("${path.module}/../ansible/group_vars/centos_aws")
+  }
   provisioner "local-exec" {
     working_dir = "${path.module}/../packer"
     command     = "packer build -force packer-centos-aws.json"
@@ -38,6 +48,11 @@ resource "null_resource" "run_packer_aws" {
 
 resource "null_resource" "run_packer_azure" {
   count = (var.build_on_azure && ! var.skip_packer_build) ? 1 : 0
+  triggers = {
+    "changes-in-playbook" : filemd5("${path.module}/../ansible/centos-azure.yml")
+    "changes-in-groupvars-all" : filemd5("${path.module}/../ansible/group_vars/all")
+    "changes-in-groupvars-azure" : filemd5("${path.module}/../ansible/group_vars/centos_azure")
+  }
   provisioner "local-exec" {
     working_dir = "${path.module}/../packer"
     command     = "packer build -force packer-centos-azure.json"


### PR DESCRIPTION
We should also check for changes in the roles, but there's no built-in md5 function for entire folders. We would need to zip, md5 and delete each role... kinda hacky... let's think about a smarter solution